### PR TITLE
Fix ios enter and exit notification

### DIFF
--- a/ios/Classes/GeofenceManager.swift
+++ b/ios/Classes/GeofenceManager.swift
@@ -88,10 +88,10 @@ class GeofenceManager: NSObject, CLLocationManagerDelegate {
 		if let knownState = regionsState[region], state != .unknown, state != knownState {
 			if let region = region as? CLCircularRegion {
 				let identifier = region.identifier
-				if state == .inside {
+				if state == .inside && region.notifyOnEntry {
 					let georegion = GeoRegion(id: identifier, radius: region.radius, latitude: region.center.latitude, longitude: region.center.longitude, events: [.entry])
 					callback(georegion)
-				} else if state == .outside {
+				} else if state == .outside && region.notifyOnExit {
 					let georegion = GeoRegion(id: identifier, radius: region.radius, latitude: region.center.latitude, longitude: region.center.longitude, events: [.exit])
 					callback(georegion)
 				}

--- a/ios/Classes/SwiftFlutterGeofencePlugin.swift
+++ b/ios/Classes/SwiftFlutterGeofencePlugin.swift
@@ -75,9 +75,9 @@ public class SwiftFlutterGeofencePlugin: NSObject, FlutterPlugin {
 	private func addRegion(identifier: String, latitude: Double, longitude: Double, radius: Double?, event: String) {
 		let events: [GeoEvent]
 		switch event {
-		case "entry":
+		case "GeolocationEvent.entry":
 			events = [.entry]
-		case "exit":
+		case "GeolocationEvent.exit":
 			events = [.exit]
 		default:
 			events = [.entry, .exit]
@@ -89,9 +89,9 @@ public class SwiftFlutterGeofencePlugin: NSObject, FlutterPlugin {
 	private func removeRegion(identifier: String, latitude: Double, longitude: Double, radius: Double?, event: String) {
 		let events: [GeoEvent]
 		switch event {
-		case "entry":
+		case "GeolocationEvent.entry":
 			events = [.entry]
-		case "exit":
+		case "GeolocationEvent.exit":
 			events = [.exit]
 		default:
 			events = [.entry, .exit]


### PR DESCRIPTION
Fixed two problems with iOS.

- SwiftFlutterGeofencePlugin.addRegion always set events = [.entry, .exit] even if each of entry/exit is specified.
- GeofenceManager was raising both enrty and exit notifications regardless of the values of notifyOnEntry and notifyOnExit of CLRegion.

With this fix, the behavior is the same on both Android and iOS.

@DwayneCoussement I would like to use your good library, but I haven't been able to install it because of this bug.
I am very disappointed and I hope you will incorporate this PR!