### PR TITLE
Fix error GeofencePlugin does nto extend Service

### DIFF
--- a/android/src/main/kotlin/com/intivoto/flutter_geofence/FlutterGeofencePlugin.kt
+++ b/android/src/main/kotlin/com/intivoto/flutter_geofence/FlutterGeofencePlugin.kt
@@ -9,6 +9,10 @@ import androidx.annotation.NonNull
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 
+import android.app.Service;
+import android.content.Intent;
+import android.os.IBinder;
+
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
@@ -19,7 +23,7 @@ import io.flutter.plugin.common.MethodChannel.Result
 import io.flutter.plugin.common.PluginRegistry
 
 /** FlutterGeofencePlugin */
-class FlutterGeofencePlugin : FlutterPlugin, MethodCallHandler, ActivityAware, PluginRegistry.RequestPermissionsResultListener {
+class FlutterGeofencePlugin() : FlutterPlugin, MethodCallHandler, ActivityAware, PluginRegistry.RequestPermissionsResultListener, Service() {
     /// The MethodChannel that will the communication between Flutter and native Android
     ///
     /// This local reference serves to register the plugin with the Flutter Engine and unregister it
@@ -28,6 +32,9 @@ class FlutterGeofencePlugin : FlutterPlugin, MethodCallHandler, ActivityAware, P
     private var geofenceManager: GeofenceManager? = null
     private var currentActivity: Activity? = null
 
+    override fun onBind(p0: Intent): IBinder? {
+        return null;
+    }
 
     override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
         channel = MethodChannel(flutterPluginBinding.getFlutterEngine().getDartExecutor(), "geofence")


### PR DESCRIPTION
Fixes issue #25 
When building for release with
```xml
<service android:name="com.intivoto.flutter_geofence.FlutterGeofencePlugin"
           android:permission="android.permission.BIND_JOB_SERVICE" android:exported="true"/>
```